### PR TITLE
bug: sorting by date now works on all browsers

### DIFF
--- a/src/components/GameSummary.js
+++ b/src/components/GameSummary.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from "styled-components";
-import broadcastNameToLogo from "../util/broadcastNameToLogo";
-import teamNameToLogo from '../util/teamNameToLogo';
+import broadcastNameToLogo from "../lib/util/broadcastNameToLogo";
+import teamNameToLogo from '../lib/util/teamNameToLogo';
 
 const Wrapper = styled.div`
   margin: 0rem 1rem 0rem 1rem;

--- a/src/components/SortButton.js
+++ b/src/components/SortButton.js
@@ -7,6 +7,7 @@ const SortButton = styled.button`
   font-size: 1rem;
   padding: .7rem 1.5rem; 
   cursor: pointer;
+  margin: 0;
 
   &:not(:last-child) {
     border-right: none;

--- a/src/lib/DataTransformer.js
+++ b/src/lib/DataTransformer.js
@@ -87,7 +87,7 @@ export default class DataTransformer {
     })
    
     games.forEach(game => {
-      let calendarDate = this.formatDate(game.gameDate)
+      let calendarDate = game.gameDate
       datesSet.add(calendarDate)
     })
 

--- a/src/lib/util/broadcastNameToLogo.js
+++ b/src/lib/util/broadcastNameToLogo.js
@@ -1,9 +1,9 @@
 import React from "react"
-import espn from "../images/broadcastImages/espn.svg" 
-import fox from "../images/broadcastImages/fox.svg" 
-import fs1 from "../images/broadcastImages/fs1.svg" 
-import mlbnet from "../images/broadcastImages/mlbnet.svg" 
-import tbs from "../images/broadcastImages/tbs.svg" 
+import espn from "../../images/broadcastImages/espn.svg"
+import fox from "../../images/broadcastImages/fox.svg" 
+import fs1 from "../../images/broadcastImages/fs1.svg" 
+import mlbnet from "../../images/broadcastImages/mlbnet.svg" 
+import tbs from "../../images/broadcastImages/tbs.svg" 
 
 const broadcastNameToLogo = name => {
   switch (name) {

--- a/src/lib/util/teamNameToLogo.js
+++ b/src/lib/util/teamNameToLogo.js
@@ -1,14 +1,14 @@
 import React from "react";
-import astros from "../images/teamImages/astros.svg" 
-import athletics from "../images/teamImages/athletics.svg" 
-import braves from "../images/teamImages/braves.svg" 
-import brewers from "../images/teamImages/brewers.svg" 
-import cubs from "../images/teamImages/cubs.svg" 
-import dodgers from "../images/teamImages/dodgers.svg" 
-import indians from "../images/teamImages/indians.svg" 
-import redsox from "../images/teamImages/redsox.svg" 
-import rockies from "../images/teamImages/rockies.svg" 
-import yankees from "../images/teamImages/yankees.svg" 
+import astros from "../../images/teamImages/astros.svg" 
+import athletics from "../../images/teamImages/athletics.svg" 
+import braves from "../../images/teamImages/braves.svg" 
+import brewers from "../../images/teamImages/brewers.svg" 
+import cubs from "../../images/teamImages/cubs.svg" 
+import dodgers from "../../images/teamImages/dodgers.svg" 
+import indians from "../../images/teamImages/indians.svg" 
+import redsox from "../../images/teamImages/redsox.svg" 
+import rockies from "../../images/teamImages/rockies.svg" 
+import yankees from "../../images/teamImages/yankees.svg" 
 
 const teamNameToLogo = team => {
   switch (team) {


### PR DESCRIPTION
Dates were being formatted twice in the data transformer. This was only an issue in safari but either waythere was no need to format the date a second time.

Safari was also adding some margin to the button group, this was fixed by adding a 0 margin. While I was doing this I moved the util folder into lib.