### PR TITLE
bug: firefox now sorts by date correctly

### DIFF
--- a/src/lib/DataTransformer.js
+++ b/src/lib/DataTransformer.js
@@ -80,9 +80,12 @@ export default class DataTransformer {
     let datesSet = new Set()
 
     let games = this.createGamesList(cleanedMlbData)
-    games.sort((a, b) => { 
-      let dateA = new Date(a.gameDate)
-      let dateB = new Date(b.gameDate)
+
+    games.sort((a, b) => {
+      // Add current year to date to ensure sort works in all browsers
+      let seasonYear = a.season
+      let dateA = new Date(`${a.gameDate}, ${seasonYear}`)
+      let dateB = new Date(`${b.gameDate}, ${seasonYear}`)
       return dateA - dateB
     })
    


### PR DESCRIPTION
Entering the date values in its current format would generate an invalid date in firefox. This was fixed by adding the year to the string.